### PR TITLE
Consumer health check command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: php
+php:
+  - 7.0
+  - 7.1
+before_script: composer install

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ As you might have noted, here we instantiate a `Publisher` not a `Producer` obje
 #### 2. Consume the Message
 In your Consumer:
 
-##### i. Register the queue and generate it's message handler
+##### i. Register the queue and generate its message handler
 In your Consumer; from the command line use the `bowler:make:subscriber` command.
 
 `php artisan bowler:make:subscriber reporting ReportingMessage --expressive`
@@ -306,6 +306,17 @@ Bowler supports application level error reporting.
 To do so, the default laravel exception handler normaly located in `app\Exceptions\Handler`, should implement `Vinelab\Bowler\Contracts\BowlerExceptionHandler`. And obviously, implement its method.
 
 `ExceptionHandler::reportQueue(Exception $e, AMQPMessage $msg)` allows you to report errors as you wish. While providing the exception and the queue message itsef for maximum flexibility.
+
+### Health Checks
+
+Based on [this Reliability Guide](https://www.rabbitmq.com/reliability.html), Bowler figured that it would be beneficial to provide
+a tool to check the health of connected consumers and is provided through the `bowler:healthcheck:consumer` command.
+
+```
+php artisan bowler:healthcheck:consumer {queue} [--consumers=1]
+```
+
+Will return exit code `0` for success and `1` for failure along with a message why.
 
 ### Important Notes
 1. It is of most importance that the users of this package, take onto their responsability the mapping between exchanges and queues. And to make sure that exchanges declaration are matching both on the producer and consumer side, otherwise a `Vinelab\Bowler\Exceptions\DeclarationMismatchException` is thrown.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bowler
 A Laravel package that implements the AMQP protocol using the *[Rabbitmq Server](https://www.rabbitmq.com)* easily and efficiently. Built on top of the *[php-amqplib](https://github.com/php-amqplib/php-amqplib/tree/master/PhpAmqpLib)*, with the aim of providing a simple abstraction layer to work with.
 
+[![Build Status](https://travis-ci.org/Vinelab/bowler.svg?branch=master)](https://travis-ci.org/Vinelab/bowler)
+
 Bowler allows you to:
 
 * Customize message publishing.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ In order to configure rabbitmq host, port, username and password, add the follow
 
 ```php
 'rabbitmq' => [
-            'host' => 'host',
-            'port' => port,
-            'username' => 'username',
-            'password' => 'password',
-        ],
+    'host' => 'host',
+    'port' => port,
+    'username' => 'username',
+    'password' => 'password',
+],
 ```
 
 And register the service provider by adding `Vinelab\Bowler\BowlerServiceProvider::class` to the providers array in `config/app`.
@@ -310,11 +310,15 @@ To do so, the default laravel exception handler normaly located in `app\Exceptio
 ### Health Checks
 
 Based on [this Reliability Guide](https://www.rabbitmq.com/reliability.html), Bowler figured that it would be beneficial to provide
-a tool to check the health of connected consumers and is provided through the `bowler:healthcheck:consumer` command.
+a tool to check the health of connected consumers and is provided through the `bowler:healthcheck:consumer` command with the following signature:
 
 ```
-php artisan bowler:healthcheck:consumer {queue} [--consumers=1]
+bowler:healthcheck:consumer
+    {queueName : The queue name}
+    {--c|consumers=1 : The expected number of consumers to be connected to the queue specified by queueName}
 ```
+
+Example: `php artisan bowler:healthcheck:consumer the-queue`
 
 Will return exit code `0` for success and `1` for failure along with a message why.
 

--- a/composer.json
+++ b/composer.json
@@ -14,23 +14,36 @@
 			"email": "kinane@vinelab.com",
 			"homepage": "https://es.linkedin.com/in/kinanedomloje",
             "role": "Backend Developer"
-		}
+		},
+        {
+            "name": "Abed Halawi",
+            "email": "abed.halawi@vinelab.com",
+            "homepage":"https://github.com/Mulkave",
+            "role": "Tech Lead"
+        }
 	],
 
 	"require": {
-		"php": ">=5.6",
-		"php-amqplib/php-amqplib": "v2.6.1"
+		"php": ">=7.0",
+		"php-amqplib/php-amqplib": "v2.6.1",
+        "illuminate/console": "5.*",
+        "illuminate/support": "5.*",
+		"mockery/mockery": "^1.0"
 	},
 
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "mockery/mockery": "^0.9.7",
-        "friendsofphp/php-cs-fixer":"^1.12"
-    },
+        "orchestra/testbench": "~3"
+	},
 
 	"autoload": {
         "psr-4": {
             "Vinelab\\Bowler\\": "src/"
+        }
+    },
+
+    "autoload-dev": {
+        "psr-4": {
+            "Vinelab\\Bowler\\Tests\\": "tests/"
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/BowlerServiceProvider.php
+++ b/src/BowlerServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Vinelab\Bowler\Console\Commands\QueueCommand;
 use Vinelab\Bowler\Console\Commands\ConsumeCommand;
 use Vinelab\Bowler\Console\Commands\SubscriberCommand;
+use Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand;
 
 /**
  * @author Ali Issa <ali@vinelab.com>
@@ -41,6 +42,7 @@ class BowlerServiceProvider extends ServiceProvider
             QueueCommand::class,
             ConsumeCommand::class,
             SubscriberCommand::class,
+            ConsumerHealthCheckCommand::class,
         ];
         $this->commands($commands);
     }

--- a/src/Console/Commands/ConsumerHealthCheckCommand.php
+++ b/src/Console/Commands/ConsumerHealthCheckCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Vinelab\Bowler\Console\Commands;
+
+use ErrorException;
+use Vinelab\Bowler\Connection;
+use Illuminate\Console\Command;
+use PhpAmqpLib\Exception\AMQPProtocolChannelException;
+
+/**
+ * @author Abed Halawi <abed.halawi@vinelab.com>
+ */
+class ConsumerHealthCheckCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'bowler:healthcheck:consumer
+                            {queueName : The queue name}
+                            {--c|consumers=1 : The expected number of consumers to be connected to the queue specified by queueName}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check the health of connected consumers to a queue, with a minimum of 1 connection.';
+
+    /**
+     * Run the command.
+     */
+    public function handle()
+    {
+        $queueName = $this->argument('queueName');
+        $expectedConsumers = (int) $this->option('consumers');
+
+        // may or may not be able to connect
+        try {
+            $connection = app(Connection::class);
+        } catch (ErrorException $e) {
+            $this->error('Unable to connect to RabbitMQ.');
+            return 1;
+        }
+
+        $channel = $connection->getChannel();
+
+        try {
+            // $queue is the same as $queueName but to avoid overriding we're naming it differently.
+            list($queue, $messageCount, $consumerCount) = $channel->queue_declare($queueName,
+                $passive = true,
+                $durable = false,
+                $exclusive = false,
+                $autoDelete = false,
+                []
+            );
+
+            // consumer count and minimum consumers connected should match
+            if ($consumerCount !== $expectedConsumers) {
+                $this->error('Health check failed. Minimum consumer count not met: expected '.$expectedConsumers.' got '.$consumerCount);
+                return 1;
+            }
+
+            $this->info('Consumers healthy with '.$consumerCount.' live connections.');
+        } catch (AMQPProtocolChannelException $e) {
+            if ($e->getCode() === 404) {
+                $this->error('Queue with name '.$queueName.' does not exist.');
+                return 1;
+            }
+
+            $this->error('An unknown channel exception occurred');
+
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/Console/Commands/ConsumerHealthCheckCommand.php
+++ b/src/Console/Commands/ConsumerHealthCheckCommand.php
@@ -64,12 +64,14 @@ class ConsumerHealthCheckCommand extends Command
 
             $this->info('Consumers healthy with '.$consumerCount.' live connections.');
         } catch (AMQPProtocolChannelException $e) {
-            if ($e->getCode() === 404) {
-                $this->error('Queue with name '.$queueName.' does not exist.');
-                return 1;
+            switch($e->getCode()) {
+                case 404:
+                    $this->error('Queue with name '.$queueName.' does not exist.');
+                    break;
+                default:
+                    $this->error('An unknown channel exception occurred.');
+                    break;
             }
-
-            $this->error('An unknown channel exception occurred');
 
             return 1;
         }

--- a/tests/Console/Commands/ConsumerHealthCheckCommandTest.php
+++ b/tests/Console/Commands/ConsumerHealthCheckCommandTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Vinelab\Bowler\Tests\Console\Commands;
+
+use Mockery as M;
+use Vinelab\Bowler\Connection;
+use Vinelab\Bowler\Tests\TestCase;
+use PhpAmqpLib\Channel\AMQPChannel;
+use Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand;
+
+class ConsumerHealthCheckCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        M::close();
+    }
+
+    public function test_checking_consumer_successfully()
+    {
+        $command = M::mock('Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand[error]');
+
+        $queueName = 'queue-to-consume';
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $mConnection = M::mock(Connection::class);
+        $mChannel = M::mock(AMQPChannel::class);
+        $mChannel->shouldReceive('queue_declare')->once()->andReturn([$queueName, 10, 1]);
+        $mConnection->shouldReceive('getChannel')->once()->andReturn($mChannel);
+
+        $this->app->bind(Connection::class, function() use($mConnection) {
+            return $mConnection;
+        });
+
+        $code = $this->artisan('bowler:healthcheck:consumer', ['queueName' => $queueName]);
+
+        $this->assertEquals(0, $code);
+    }
+
+    public function test_with_0_expected_1_connected()
+    {
+        // should err out requesting minimum to be greater than 0
+        $command = M::mock('Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand[error]');
+        $command->shouldReceive('error')->once()->with('Health check failed. Minimum consumer count not met: expected 0 got 1');
+
+        $queueName = 'queue-to-consume';
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $mConnection = M::mock(Connection::class);
+        $mChannel = M::mock(AMQPChannel::class);
+        $mChannel->shouldReceive('queue_declare')->once()->andReturn([$queueName, 10, 1]);
+        $mConnection->shouldReceive('getChannel')->once()->andReturn($mChannel);
+
+        $this->app->bind(Connection::class, function() use($mConnection) {
+            return $mConnection;
+        });
+
+        $code = $this->artisan('bowler:healthcheck:consumer', ['queueName' => $queueName, '--consumers' => 0]);
+
+        $this->assertEquals(1, $code);
+    }
+
+    public function test_with_1_expected_0_connected()
+    {
+        // should err out requesting minimum to be greater than 0
+        $command = M::mock('Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand[error]');
+        $command->shouldReceive('error')->once()->with('Health check failed. Minimum consumer count not met: expected 1 got 0');
+
+        $queueName = 'queue-to-consume';
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $mConnection = M::mock(Connection::class);
+        $mChannel = M::mock(AMQPChannel::class);
+        $mChannel->shouldReceive('queue_declare')->once()->andReturn([$queueName, 10, 0]);
+        $mConnection->shouldReceive('getChannel')->once()->andReturn($mChannel);
+
+        $this->app->bind(Connection::class, function() use($mConnection) {
+            return $mConnection;
+        });
+
+        $code = $this->artisan('bowler:healthcheck:consumer', ['queueName' => $queueName, '--consumers' => 1]);
+
+        $this->assertEquals(1, $code);
+    }
+
+    public function test_healthcheck_with_queue_does_not_exist()
+    {
+        // should err out with an error message indicating the case
+        $command = M::mock('Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand[error]');
+        $command->shouldReceive('error')->once()->with('Queue with name the-queue does not exist.');
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $code = $this->artisan('bowler:healthcheck:consumer', ['queueName' => 'the-queue']);
+
+        $this->assertEquals(1, $code);
+    }
+
+    public function test_error_connecting_to_rabbitmq()
+    {
+        $command = M::mock('Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand[error]');
+        $command->shouldReceive('error')->once()->with('Unable to connect to RabbitMQ.');
+
+        $this->app->bind(Connection::class, function () {
+            return new Connection('', '', '', '');
+        });
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $code = $this->artisan('bowler:healthcheck:consumer', ['queueName' => 'the-queue']);
+
+        $this->assertEquals(1, $code);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Vinelab\Bowler\Tests;
+
+use Vinelab\Bowler\BowlerServiceProvider;
+use Orchestra\Testbench\TestCase as OTestCase;
+
+/**
+ * @author Abed Halawi <abed.halawi@vinelab.com>
+ */
+class TestCase extends OTestCase
+{
+    public function test_sample()
+    {
+        // just to skip warnings
+        $this->assertEquals(1, 1);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        $this->getEnvironmentSetUp($app);
+
+        return [BowlerServiceProvider::class];
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('queue.connections.rabbitmq.host', 'localhost');
+        $app['config']->set('queue.connections.rabbitmq.port', 5672);
+        $app['config']->set('queue.connections.rabbitmq.username', 'guest');
+        $app['config']->set('queue.connections.rabbitmq.password', 'guest');
+    }
+}


### PR DESCRIPTION
Provides `php artisan bowler:healthcheck:consumer {queue} [--consumers=1]` to check the number of connected consumers according to the expected number in `--consumers`.