### PR TITLE
Revamp the health check mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,13 +358,13 @@ To do so, the default laravel exception handler normaly located in `app\Exceptio
 
 ### Health Checks
 
+**IMPORTANT: Management plugin is required to be installed in order to perform health checks.**
+
 Based on [this Reliability Guide](https://www.rabbitmq.com/reliability.html), Bowler figured that it would be beneficial to provide
 a tool to check the health of connected consumers and is provided through the `bowler:healthcheck:consumer` command with the following signature:
 
 ```
-bowler:healthcheck:consumer
-    {queueName : The queue name}
-    {--c|consumers=1 : The expected number of consumers to be connected to the queue specified by queueName}
+bowler:healthcheck:consumer {queueName : The queue name}
 ```
 
 Example: `php artisan bowler:healthcheck:consumer the-queue`

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,9 @@
 		"php": ">=7.0",
 		"php-amqplib/php-amqplib": "v2.6.1",
         "illuminate/console": "5.*",
-        "illuminate/support": "5.*"
+        "illuminate/support": "5.*",
+		"vinelab/http": "^1.5",
+		"illuminate/filesystem": "5.x"
     },
 
     "require-dev": {

--- a/src/BowlerServiceProvider.php
+++ b/src/BowlerServiceProvider.php
@@ -19,8 +19,14 @@ class BowlerServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // register facade to resolve instance
         $this->app->singleton('vinelab.bowler.registrator', function ($app) {
             return new RegisterQueues();
+        });
+
+        // use the same Registrator instance all over the app (to make it injectable).
+        $this->app->singleton(RegisterQueues::class, function ($app) {
+            return $app['vinelab.bowler.registrator'];
         });
 
         // Bind connection to env configuration

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -35,7 +35,7 @@ class Connection
      *
      * @var string
      */
-    private $host;
+    private $host = 'localhost';
 
     /**
      * Management plugin's port.
@@ -49,14 +49,14 @@ class Connection
      *
      * @var string
      */
-    private $username;
+    private $username = 'guest';
 
     /**
      * RabbitMQ server password.
      *
      * @var string
      */
-    private $password;
+    private $password = 'guest';
 
     /**
      * @param string $host      the ip of the rabbitmq server, default: localhost

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -5,6 +5,7 @@ namespace Vinelab\Bowler;
 define('__ROOT__', dirname(dirname(dirname(__FILE__))));
 //require_once(__ROOT__.'/vendor/autoload.php');
 
+use Vinelab\Http\Client as HTTPClient;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 /**
@@ -30,6 +31,34 @@ class Connection
     private $channel;
 
     /**
+     * RabbitMQ server host.
+     *
+     * @var string
+     */
+    private $host;
+
+    /**
+     * Management plugin's port.
+     *
+     * @var int
+     */
+    private $managementPort = 15672;
+
+    /**
+     * RabbitMQ server username.
+     *
+     * @var string
+     */
+    private $username;
+
+    /**
+     * RabbitMQ server password.
+     *
+     * @var string
+     */
+    private $password;
+
+    /**
      * @param string $host      the ip of the rabbitmq server, default: localhost
      * @param int    $port.     default: 5672
      * @param string $username, default: guest
@@ -37,6 +66,11 @@ class Connection
      */
     public function __construct($host = 'localhost', $port = 5672, $username = 'guest', $password = 'guest')
     {
+        $this->host = $host;
+        $this->poart = $port;
+        $this->username = $username;
+        $this->password = $password;
+
         $this->connection = new AMQPStreamConnection(
             $host,
             $port,
@@ -65,6 +99,30 @@ class Connection
     public function getChannel()
     {
         return $this->channel;
+    }
+
+    /**
+     * Fetch the list of consumers details for the given queue name using the management API.
+     *
+     * @param  string $queueName
+     * @param  string $columns
+     *
+     * @return array
+     */
+    public function fetchQueueConsumers($queueName, string $columns = 'consumer_details.consumer_tag')
+    {
+        $http = app(HTTPClient::class);
+
+        $request = [
+            'url' => $this->host.':'.$this->managementPort.'/api/queues/%2F/'.$queueName,
+            'params' => ['columns' => $columns],
+            'auth' => [
+                'username' => $this->username,
+                'password' => $this->password,
+            ],
+        ];
+
+        return $http->get($request)->json();
     }
 
     public function __destruct()

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -3,6 +3,7 @@
 namespace Vinelab\Bowler;
 
 use Vinelab\Bowler\Traits\AdminTrait;
+use Vinelab\Bowler\Traits\ConsumerTagTrait;
 use Vinelab\Bowler\Traits\DeadLetteringTrait;
 use Vinelab\Bowler\Traits\CompileParametersTrait;
 use Vinelab\Bowler\Exceptions\Handler as BowlerExceptionHandler;
@@ -16,6 +17,7 @@ use Vinelab\Bowler\Exceptions\Handler as BowlerExceptionHandler;
 class Consumer
 {
     use AdminTrait;
+    use ConsumerTagTrait;
     use DeadLetteringTrait;
     use CompileParametersTrait;
 
@@ -156,7 +158,9 @@ class Consumer
         };
 
         $channel->basic_qos(null, 1, null);
-        $channel->basic_consume($this->queueName, '', false, false, false, false, $callback);
+        $tag = $channel->basic_consume($this->queueName, '', false, false, false, false, $callback);
+
+        $this->writeConsumerTag($tag);
 
         echo ' [*] Listening to Queue: ', $this->queueName, ' To exit press CTRL+C', "\n";
 

--- a/src/Traits/ConsumerTagTrait.php
+++ b/src/Traits/ConsumerTagTrait.php
@@ -9,18 +9,18 @@ use Storage;
  */
 trait ConsumerTagTrait
 {
-    public function getConsumerTagFilePath()
+    public function getConsumerTagFilename()
     {
-        return storage_path().'/app/rabbitmq-consumer.tag';
+        return 'rabbitmq-consumer.tag';
     }
 
     private function writeConsumerTag($tag)
     {
-        Storage::disk('local')->put($this->getConsumerTagFilePath(), $tag);
+        Storage::disk('local')->put($this->getConsumerTagFilename(), $tag);
     }
 
     public function readConsumerTag()
     {
-        return Storage::disk('local')->get($this->getConsumerTagFilePath());
+        return Storage::disk('local')->get($this->getConsumerTagFilename());
     }
 }

--- a/src/Traits/ConsumerTagTrait.php
+++ b/src/Traits/ConsumerTagTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Vinelab\Bowler\Traits;
+
+use Storage;
+
+/**
+ * @author Abed Halawi <abed.halawi@vinelab.com>
+ */
+trait ConsumerTagTrait
+{
+    public function getConsumerTagFilePath()
+    {
+        return storage_path().'/app/rabbitmq-consumer.tag';
+    }
+
+    private function writeConsumerTag($tag)
+    {
+        Storage::disk('local')->put($this->getConsumerTagFilePath(), $tag);
+    }
+
+    public function readConsumerTag()
+    {
+        return Storage::disk('local')->get($this->getConsumerTagFilePath());
+    }
+}

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Vinelab\Bowler\Tests;
+
+use Mockery as M;
+use Vinelab\Bowler\Connection;
+use Vinelab\Http\Client as HTTPClient;
+
+/**
+ * @author Abed Halawi <abed.halawi@vinelab.com>
+ */
+class ConnectionTest extends TestCase
+{
+    public function tearDown()
+    {
+        M::close();
+    }
+
+    public function test_fetching_consumers_default()
+    {
+        $queueName = 'the-queue';
+        $mClient = M::mock(HTTPClient::class);
+        $request = [
+            'url' => 'localhost:15672/api/queues/%2F/'.$queueName,
+            'params' => ['columns' => 'consumer_details.consumer_tag'],
+            'auth' => [
+                'username' => 'guest',
+                'password' => 'guest',
+            ],
+        ];
+
+        $mClient->shouldReceive('get')->once()->with($request)->andReturn($mClient);
+        $mClient->shouldReceive('json')->once()->withNoArgs()->andReturn('response');
+
+        $this->app->bind(HTTPClient::class, function () use ($mClient) {
+            return $mClient;
+        });
+
+        $mConnection = M::mock(Connection::class)->makePartial();
+        $this->app->bind(Connection::class, function () use ($mConnection) {
+            return $mConnection;
+        });
+
+        $connection = $this->app[Connection::class];
+        $response = $connection->fetchQueueConsumers($queueName);
+
+        $this->assertEquals('response', $response);
+    }
+}


### PR DESCRIPTION
Before: we used to check for the number of consumers connected and compare it to an expected number of consumers, if that didn't match the current consumer reports a health problem. This proved to be unreliable as more consumers get connected to the same queue, gradually it starts breaking consumers it shouldn't.

Now: The new way of performing health checks consists of checking the current consumer by its tag. When the consumer connects to the queue, RabbitMQ returns the tag generated for this consumer. Once done, Bowler saves this tag to a file in the app's storage path and uses the Management Plugin to fetch the list of connected consumers to the indicated queue and checks for this consumer's tag among the list.