### PR TITLE
Consumer: move handler initialisation to inside the message receipt callback

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -139,10 +139,10 @@ class Consumer
             $channel->queue_bind($this->queueName, $this->exchangeName);
         }
 
-        // Instantiate Handler
-        $queueHandler = app($handlerClass);
+        $callback = function ($message) use ($handlerClass, $exceptionHandler) {
+            // Instantiate Handler
+            $queueHandler = app($handlerClass);
 
-        $callback = function ($message) use ($queueHandler, $exceptionHandler) {
             $broker = new MessageBroker($message);
 
             try {


### PR DESCRIPTION
With this change the handlers are initialised once per message receipt and then destroyed. This would help preserve memory during a consumer session (run-loop) and protect from memory leaks that could be introduced when handling messages by not using the same instance throughout the session (leaks will be destroyed with the instance).