### PR TITLE
Improve code intelligence facilities and provide other minor fixes and improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,43 +1,44 @@
 {
-	"name": "vinelab/bowler",
-	"description": "A Rabbitmq wrapper for Laravel",
-	"license": "MIT",
-	"keywords": ["php", "json", "rabbitmq", "amqp", "api", "microservices"],
-	"authors": [
-		{
-			"name": "Ali Issa",
-			"email": "ali@vinelab.com",
-			"role": "Backend Software Engineer"
-		},
-		{
-			"name": "Kinane Domloje",
-			"email": "kinane@vinelab.com",
-			"homepage": "https://es.linkedin.com/in/kinanedomloje",
+    "name": "vinelab/bowler",
+    "description": "A Rabbitmq wrapper for Laravel",
+    "license": "MIT",
+    "keywords": ["php", "json", "rabbitmq", "amqp", "api", "microservices"],
+    "authors": [
+        {
+            "name": "Ali Issa",
+            "email": "ali@vinelab.com",
+            "role": "Backend Software Engineer"
+        },
+        {
+            "name": "Kinane Domloje",
+            "email": "kinane@vinelab.com",
+            "homepage": "https://es.linkedin.com/in/kinanedomloje",
             "role": "Backend Developer"
-		},
+        },
         {
             "name": "Abed Halawi",
             "email": "abed.halawi@vinelab.com",
             "homepage":"https://github.com/Mulkave",
             "role": "Tech Lead"
         }
-	],
+    ],
 
-	"require": {
-		"php": ">=7.0",
-		"php-amqplib/php-amqplib": "v2.8.1",
-        "illuminate/console": "5.*",
-        "illuminate/support": "5.*",
-		"vinelab/http": "^1.5",
-		"illuminate/filesystem": "5.x"
+    "require": {
+        "php": ">=7.0",
+        "php-amqplib/php-amqplib": "v2.8.1",
+        "illuminate/console": "5.4.*|5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*",
+        "vinelab/http": "^1.5",
+        "illuminate/filesystem": "5.4.*|5.5.*|5.6.*|5.7.*"
     },
 
     "require-dev": {
-		"mockery/mockery": "^1.0",
-        "orchestra/testbench": "~3"
-	},
+        "mockery/mockery": "^1.0",
+        "orchestra/testbench": "3.4.*",
+        "phpunit/phpunit": "~5.7"
+    },
 
-	"autoload": {
+    "autoload": {
         "psr-4": {
             "Vinelab\\Bowler\\": "src/"
         }

--- a/src/Console/Commands/ConsumeCommand.php
+++ b/src/Console/Commands/ConsumeCommand.php
@@ -53,6 +53,7 @@ class ConsumeCommand extends Command
 
     /**
      * Run the command.
+     * @throws UnregisteredQueueException
      */
     public function handle()
     {

--- a/src/Console/Commands/QueueCommand.php
+++ b/src/Console/Commands/QueueCommand.php
@@ -2,7 +2,9 @@
 
 namespace Vinelab\Bowler\Console\Commands;
 
+use Exception;
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Vinelab\Bowler\Generators\HandlerGenerator;
 
 /**
@@ -57,6 +59,9 @@ class QueueCommand extends Command
         }
     }
 
+    /**
+     * @return array
+     */
     public function getArguments()
     {
         return [

--- a/src/Console/Commands/SubscriberCommand.php
+++ b/src/Console/Commands/SubscriberCommand.php
@@ -2,6 +2,7 @@
 
 namespace Vinelab\Bowler\Console\Commands;
 
+use Exception;
 use Illuminate\Console\Command;
 use Vinelab\Bowler\Generators\HandlerGenerator;
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -11,13 +11,19 @@ class Dispatcher extends Producer
      * Part of the fair dispatch implementation
      * Allow setting the exchange name and type with default of `topic`.
      *
-     * @param Vinelab\Bowler\Connection $connection
+     * @param Connection $connection
      */
     public function __construct(Connection $connection)
     {
         parent::__construct($connection);
     }
 
+    /**
+     * @param string $exchangeName
+     * @param string $routingKey
+     * @param string|null $data
+     * @param string $exchangeType
+     */
     public function dispatch($exchangeName, $routingKey, $data = null, $exchangeType = 'topic')
     {
         $this->setup($exchangeName, $exchangeType);

--- a/src/Facades/Registrator.php
+++ b/src/Facades/Registrator.php
@@ -5,7 +5,11 @@ namespace Vinelab\Bowler\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \App\Foundation\Pagination\PaginationQuery
+ * @method static void queue(string $queue, string $className, array $options)
+ * @method static void subscriber(string $queue, string $className, array $bindingKeys, string $exchangeName, string $exchangeType)
+ * @method static array getHandlers()
+ *
+ * @see \Vinelab\Bowler\RegisterQueues
  */
 class Registrator extends Facade
 {

--- a/src/Generators/stubs/handler.stub
+++ b/src/Generators/stubs/handler.stub
@@ -2,12 +2,16 @@
 
 namespace {{namespace}};
 
+use Exception;
+use PhpAmqpLib\Message\AMQPMessage;
+use Vinelab\Bowler\MessageBroker;
+
 class {{handler}}
 {
     /**
      * Handle message.
      *
-     * @param PhpAmqpLib\Message\AMQPMessage $msg
+     * @param AMQPMessage $msg
      *
      * @return void
      */
@@ -19,8 +23,8 @@ class {{handler}}
     /**
      * Handle error
      *
-     * @param \Exception                    $e
-     * @param Vinelab\Bowler\MessageBroker  $broker
+     * @param Exception $e
+     * @param MessageBroker $broker
      *
      * @return void
      */

--- a/src/MessageBroker.php
+++ b/src/MessageBroker.php
@@ -15,10 +15,14 @@ class MessageBroker
     /**
      * The received message.
      *
-     * @var PhpAmqpLib\Message\AMQPMessage
+     * @var AMQPMessage
      */
     protected $message;
 
+    /**
+     * MessageBroker constructor.
+     * @param AMQPMessage $message
+     */
     public function __construct(AMQPMessage $message)
     {
         $this->message = $message;
@@ -27,7 +31,7 @@ class MessageBroker
     /**
      * Get message.
      *
-     * @return PhpAmqpLib\Message\AMQPMessage
+     * @return AMQPMessage
      */
     public function getMessage()
     {

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -19,7 +19,7 @@ class Producer
     /**
      * The main class of the package where we define the channel and the connection.
      *
-     * @var Vinelab\Bowler\Connection
+     * @var Connection
      */
     protected $connection;
 
@@ -73,7 +73,7 @@ class Producer
     protected $deliveryMode;
 
     /**
-     * @param Vinelab\Bowler\Connection $connection
+     * @param Connection $connection
      */
     public function __construct(Connection $connection)
     {

--- a/src/Publisher.php
+++ b/src/Publisher.php
@@ -11,7 +11,7 @@ class Publisher extends Producer
      * Part of the out-of-the-box Pub/Sub implementation
      * Set the default exchange named `pub-sub` of type `topic`.
      *
-     * @param Vinelab\Bowler\Connection $connection
+     * @param Connection $connection
      */
     public function __construct(Connection $connection)
     {

--- a/src/RegisterQueues.php
+++ b/src/RegisterQueues.php
@@ -10,6 +10,9 @@ use Vinelab\Bowler\Exceptions\InvalidSubscriberBindingException;
  */
 class RegisterQueues
 {
+    /**
+     * @var array
+     */
     private $handlers = [];
 
     /**
@@ -35,7 +38,10 @@ class RegisterQueues
      *
      * @param string $queue
      * @param string $className
-     * @param array  $bindingKeys
+     * @param array $bindingKeys
+     * @param string $exchangeName
+     * @param string $exchangeType
+     * @throws InvalidSubscriberBindingException
      */
     public function subscriber($queue, $className, array $bindingKeys, $exchangeName = 'pub-sub', $exchangeType = 'topic')
     {
@@ -57,6 +63,9 @@ class RegisterQueues
         $this->queue($queue, $className, $options);
     }
 
+    /**
+     * @return array
+     */
     public function getHandlers()
     {
         return $this->handlers;


### PR DESCRIPTION
## Overview

This PR offers the following improvements:
- Fixes invalid class references due to missing use statements (namely some exceptions in try-catch blocks and Symfony Console's `InputArgument`)
- Adds or fixes phpdoc comments and object type hints for **significantly improved code intelligence** in PhpStorm. Getting these right was the main motive behind this PR
- Fixes version constraints in `composer.json` because the currently installed packages are incompatible with one another and targeted version of PHP. Also replaces tab indentation with spaces in `composer.json`.