### PR TITLE
Apply contextual binding for exception handler

### DIFF
--- a/src/BowlerServiceProvider.php
+++ b/src/BowlerServiceProvider.php
@@ -2,12 +2,13 @@
 
 namespace Vinelab\Bowler;
 
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Support\ServiceProvider;
 use Vinelab\Bowler\Console\Commands\QueueCommand;
 use Vinelab\Bowler\Console\Commands\ConsumeCommand;
 use Vinelab\Bowler\Console\Commands\SubscriberCommand;
 use Vinelab\Bowler\Console\Commands\ConsumerHealthCheckCommand;
-use Vinelab\Bowler\Contracts\BowlerExceptionHandler;
+use Vinelab\Bowler\Exceptions\Handler as BowlerExceptionHandler;
 
 /**
  * @author Ali Issa <ali@vinelab.com>
@@ -63,7 +64,9 @@ class BowlerServiceProvider extends ServiceProvider
             return new Connection($rbmqHost, $rbmqPort, $rbmqUsername, $rbmqPassword, $rbmqConnectionTimeout, $rbmqReadWriteTimeout, $rbmqHeartbeat, $rbmqVhost);
         });
 
-        $this->app->bind(BowlerExceptionHandler::class, $this->app->getNamespace().'Exceptions\Handler');
+        $this->app->when(BowlerExceptionHandler::class)
+            ->needs(ExceptionHandler::class)
+            ->give($this->app->getNamespace().'Exceptions\Handler');
 
         //register command
         $this->commands([


### PR DESCRIPTION
Without contextual binding we'll always resolve either Laravel's base exception handler (under new implementation) or implementation of `BowlerExceptionHandler` contract (under previous implementation). 

As discussed previously, the intended result of error handling improvements is to have app exception handler that optionally implements `BowlerExceptionHandler` contract. If the consumer of the library chose not to implement the contract, the default error reporting behavior kicks in.