### PR TITLE
Laravel 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Homestead.yaml
 .DS_Store
 composer.lock
 phpunit.xml
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 php:
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 before_script: composer install

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     "require": {
         "php": ">=7.0",
         "php-amqplib/php-amqplib": "v2.8.1",
-        "illuminate/console": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
-        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
-        "illuminate/filesystem": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
+        "illuminate/console": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.* || ^6",
+        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.* || ^6",
+        "illuminate/filesystem": "5.4.*|5.5.*|5.6.*|5.7.*|5.8.* || ^6",
         "vinelab/http": "^1.5"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -26,16 +26,16 @@
     "require": {
         "php": ">=7.0",
         "php-amqplib/php-amqplib": "v2.8.1",
-        "illuminate/console": "5.4.*|5.5.*|5.6.*|5.7.*",
-        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.*",
-        "vinelab/http": "^1.5",
-        "illuminate/filesystem": "5.4.*|5.5.*|5.6.*|5.7.*"
+        "illuminate/console": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
+        "illuminate/support": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
+        "illuminate/filesystem": "5.4.*|5.5.*|5.6.*|5.7.* || ^6",
+        "vinelab/http": "^1.5"
     },
 
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench": "3.4.*",
-        "phpunit/phpunit": "~5.7"
+        "orchestra/testbench": "3.4.* || ^4",
+        "phpunit/phpunit": "~5.7 || ~8.3"
     },
 
     "autoload": {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -14,7 +14,7 @@ use PhpAmqpLib\Connection\AMQPStreamConnection;
  */
 class ConnectionTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown() : void
     {
         M::close();
     }

--- a/tests/Console/Commands/ConsumerHealthCheckCommandTest.php
+++ b/tests/Console/Commands/ConsumerHealthCheckCommandTest.php
@@ -14,7 +14,7 @@ use PhpAmqpLib\Exception\AMQPProtocolChannelException;
  */
 class ConsumerHealthCheckCommandTest extends TestCase
 {
-    public function tearDown()
+    public function tearDown() : void
     {
         M::close();
     }

--- a/tests/MessageLifecycleManagerTest.php
+++ b/tests/MessageLifecycleManagerTest.php
@@ -24,7 +24,7 @@ class MessageLifecycleManagerTest extends TestCase
      */
     private $config;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
         $this->logger = Mockery::spy(Log::class);


### PR DESCRIPTION
Make package compatible with Laravel 6
Also bump min php version from 7.0 to 7.1

I checked, and none of the changes affect backwards versions. The only "breaking" change is bumping the PHP vesion, but PHP 7.0 (and in fact even 7.1) hasn't been supported for a while.

One note I wanted to raise, the use of `assertAttributeEquals` is deprecated in phpunit 8 and will be removed in 9. It has no direct replacement, but I think the thing to do is just to add getter methods to the Connection class, which will allow testing. Or alternatively, creating a testing double that extends Connection and has those getter methods. I would be happy to implement either option, just let me know which you think is best.